### PR TITLE
Move noarch Erlang packages into /usr/share/erlang/lib.

### DIFF
--- a/erlang-find-requires.py
+++ b/erlang-find-requires.py
@@ -205,6 +205,7 @@ def inspect_so_library(library, export_name, dependency_name):
 def inspect_beam_file(ISA, filename):
     # Get the main Erlang directory
     ERLLIBDIR = glob.glob("/usr/lib*/erlang/lib")[0]
+    ERLSHRDIR = "/usr/share/erlang/lib"
 
     b = pybeam.BeamFile(filename)
     # [(M,F,A),...]
@@ -224,7 +225,7 @@ def inspect_beam_file(ISA, filename):
     # TODO let's find modules which provides these requires
     for (M,F,A) in BeamMFARequires:
         # FIXME check in noarch Erlang dir also
-        if not check_for_mfa("%s/*/ebin" % ERLLIBDIR, Dict, (M, F, A)):
+        if not check_for_mfa("%s/*/ebin" % ERLLIBDIR, Dict, (M, F, A)) and not check_for_mfa("%s/*/ebin" % ERLSHRDIR, Dict, (M, F, A)):
             print("ERROR: Cant find %s:%s/%d while processing '%s'" % (M,F,A, filename), file=sys.stderr)
             # We shouldn't stop further processing here - let pretend this is just a warning
             #exit(1)

--- a/macros.erlang
+++ b/macros.erlang
@@ -1,7 +1,7 @@
 # handy macros for erlang-related packages
 
 %_erldir	%{_libdir}/erlang
-%_erllibdir	%{_erldir}/lib
+%_erllibdir	%(a=%{buildarch}; if [ "$a" == "noarch" ] ; then echo %{_datadir}/erlang/lib; else echo %{_erldir}/lib; fi)
 
 %__rebar /usr/bin/rebar
 
@@ -16,6 +16,7 @@
 	echo "{{git, \\\"%{_builddir}/%{buildsubdir}\\\"}, \\\"%{version}\\\"}." > %{_builddir}/%{buildsubdir}/vsn.cache ; \
 	REBAR_DEPS_PREFER_LIBS="TRUE" ; export REBAR_DEPS_PREFER_LIBS ; \
 	IGNORE_MISSING_DEPS="TRUE" ; export IGNORE_MISSING_DEPS ; \
+	ERL_LIBS="%{_datadir}/erlang/lib/" ; export ERL_LIBS ; \
 	%__rebar compile skip_deps=true -vv \
 %{nil}
 


### PR DESCRIPTION
This pull request depends on https://bugzilla.redhat.com/show_bug.cgi?id=1476614 being merged and built first. Once we have Erlang searching /usr/share/erlang/lib, we can merge this and start building noarch Erlang packages!

IMO, we don't need to do a mass rebuild due to this - I think we can just fix up Erlang packages slowly over time. We will need to switch the packages that don't have C code to declare themselves as noarch and rebuild. Any packages that aren't changed will continue to work as they do today.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>